### PR TITLE
chore: pin Flutter 3.24.0 via FVM + docs

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "3.24.0",
+  "flavors": {}
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
 
+## FVM (Flutter Version Manager)
+
+Recomanat per fixar la versió de Flutter a l'entorn de desenvolupament i CI.
+
+- Instal·la FVM: `dart pub global activate fvm`
+- Usa la versió configurada (3.24.0): `fvm use 3.24.0 --force`
+- Executa comandes amb FVM: `fvm flutter pub get`, `fvm flutter test`
+
+Arxiu de configuració: `.fvm/fvm_config.json`
+
 ## Execució i configuració ràpida
 
 Variables d'entorn via `--dart-define`:


### PR DESCRIPTION
- Add .fvm/fvm_config.json pinned to Flutter 3.24.0
- Update README: FVM install/use + Running/Testing notes
- No product code changes

Acceptance:
- CI green
- FVM version visible with `fvm flutter --version`